### PR TITLE
fix: public_member_api_docs rules not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Fix the public_member_api_docs rule not being applied
 
 ## 0.0.1
 

--- a/lib/packages.yaml
+++ b/lib/packages.yaml
@@ -1,5 +1,9 @@
 include: package:dart_lint_rules/core.yaml
 
+linter:
+  rules:
+    - public_member_api_docs
+
 analyzer:
   errors:
     public_member_api_docs: warning

--- a/lib/packages.yaml
+++ b/lib/packages.yaml
@@ -6,4 +6,4 @@ linter:
 
 analyzer:
   errors:
-    public_member_api_docs: warning
+    public_member_api_docs: info


### PR DESCRIPTION
## Description
The `public_member_api_docs` rule wasn't applied because it wasn't be declared.